### PR TITLE
CI: fix up GitHub actions and Travis CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
     - name: Run tests
       run: |
         set -vxeuo pipefail

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -20,6 +20,7 @@ build_config:
 	python build_config.py "${TEST_CONFIG_PATH}" "${TEST_OVERRIDE_PATH}"
 	find ${TEST_CONFIG_PATH}
 	mkdir -p logs
+	chmod 0777 logs
 
 run: build_config
 	docker run --rm $(DOCKER_RUN_FLAGS) -t \

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -20,7 +20,6 @@ build_config:
 	python build_config.py "${TEST_CONFIG_PATH}" "${TEST_OVERRIDE_PATH}"
 	find ${TEST_CONFIG_PATH}
 	mkdir -p logs
-	chmod 0777 logs
 
 run: build_config
 	docker run --rm $(DOCKER_RUN_FLAGS) -t \

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -19,9 +19,10 @@ build_config:
 	cp -r ${PCDS_LOGSTASH_ROOT}/conf.d/ ${TEST_CONFIG_PATH}
 	python build_config.py "${TEST_CONFIG_PATH}" "${TEST_OVERRIDE_PATH}"
 	find ${TEST_CONFIG_PATH}
+	mkdir -p logs
+	chmod 0777 logs
 
 run: build_config
-	mkdir -p logs
 	docker run --rm $(DOCKER_RUN_FLAGS) -t \
 		\
 		-v ${PCDS_LOGSTASH_ROOT}/testing/logs:/var/log/logstash \

--- a/testing/build_config.py
+++ b/testing/build_config.py
@@ -3,12 +3,12 @@ import shutil
 import sys
 import string
 
-import logstash_test
+import conftest
 
 config_path = pathlib.Path(sys.argv[1])
 test_override_path = pathlib.Path(sys.argv[2])
 
-for message_type, info in logstash_test.message_types.items():
+for message_type, info in conftest.message_types.items():
     if message_type == "python_json_udp":
         continue
     if message_type == "python_json_tcp":

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,33 @@
+message_types = {
+    'epics_errlog': dict(
+        protocol='tcp',
+        port=7004,            # <-- this is the port logstash expects errlog on
+        receive_port=17771,   # <-- this is the port we configure logstash to send us info
+    ),
+    'caputlog': dict(
+        protocol='tcp',
+        port=7011,
+        receive_port=17772,
+    ),
+    'plc': dict(
+        protocol='udp',
+        # port=54321,  # <-- NOTE: this goes to the UDP tee process (on prod)
+        port=54322,  # <-- NOTE: this goes directly to logstash
+        receive_port=17773,
+    ),
+    'python_json_tcp': dict(
+        protocol='tcp',
+        port=54320,
+        receive_port=17774,
+    ),
+    'python_json_udp': dict(
+        protocol='udp',
+        port=54320,
+        receive_port=17774,
+    ),
+    'gateway_caputlog': dict(
+        protocol='tcp',
+        port=17775,
+        receive_port=17776,
+    ),
+}

--- a/testing/logstash_test.py
+++ b/testing/logstash_test.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     pcdsutils = None
 
+import conftest
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ def send_message(port, protocol, message):
 
 def send_by_type(message_type, message):
     """Send a message given the message type and message itself."""
-    info = message_types[message_type]
+    info = conftest.message_types[message_type]
     port = info['port']
     protocol = info['protocol']
     return send_message(port, protocol, message)
@@ -114,40 +115,6 @@ def check_vs_expected(expected, received):
     if errors:
         raise ValueError('\n' + '\n\n'.join(errors))
 
-
-message_types = {
-    'epics_errlog': dict(
-        protocol='tcp',
-        port=7004,            # <-- this is the port logstash expects errlog on
-        receive_port=17771,   # <-- this is the port we configure logstash to send us info
-    ),
-    'caputlog': dict(
-        protocol='tcp',
-        port=7011,
-        receive_port=17772,
-    ),
-    'plc': dict(
-        protocol='udp',
-        # port=54321,  # <-- NOTE: this goes to the UDP tee process (on prod)
-        port=54322,  # <-- NOTE: this goes directly to logstash
-        receive_port=17773,
-    ),
-    'python_json_tcp': dict(
-        protocol='tcp',
-        port=54320,
-        receive_port=17774,
-    ),
-    'python_json_udp': dict(
-        protocol='udp',
-        port=54320,
-        receive_port=17774,
-    ),
-    'gateway_caputlog': dict(
-        protocol='tcp',
-        port=17775,
-        receive_port=17776,
-    ),
-}
 
 tests = [
     # -- error log tests --
@@ -311,7 +278,7 @@ def check_timestamp(result):
 
 @pytest.mark.parametrize('message_type, message, expected', tests)
 def test_all(message_type, message, expected):
-    info = message_types[message_type]
+    info = conftest.message_types[message_type]
     result = send_and_receive(info['port'], info['receive_port'],
                               info['protocol'], message)
     check_vs_expected(expected, result)
@@ -321,7 +288,7 @@ def test_all(message_type, message, expected):
 @pytest.mark.parametrize('message_type, message, expected, exc_class',
                          fail_tests)
 def test_should_fail(message_type, message, expected, exc_class):
-    info = message_types[message_type]
+    info = conftest.message_types[message_type]
     result = send_and_receive(info['port'], info['receive_port'],
                               info['protocol'], message)
 
@@ -339,7 +306,7 @@ def test_python_logging(python_message_type):
     if pcdsutils is None:
         pytest.skip('pcdsutils unavailable')
 
-    info = message_types[python_message_type]
+    info = conftest.message_types[python_message_type]
     pcdsutils.log.configure_pcds_logging(
         log_host=LOG_HOST,
         log_port=info['port'],
@@ -371,7 +338,7 @@ def test_python_logging_exceptions(python_message_type):
     if pcdsutils is None:
         pytest.skip('pcdsutils unavailable')
 
-    info = message_types[python_message_type]
+    info = conftest.message_types[python_message_type]
     pcdsutils.log.configure_pcds_logging(
         log_host=LOG_HOST,
         log_port=info['port'],


### PR DESCRIPTION
## GitHub actions

Now that GH Actions have been added alongside the Travis CI configuration, try to make them work in this PR.

## Notes
* GH actions resulted in the same issue that Travis CI was showing from 4a2d978
* This led me to dig into the logs a bit more, and it appears that due to `/var/log/logstash` permissions, it wasn't able to write a log file and then closed the pipeline prior to finishing evaluation of it
* It appears that this functionality differs slightly on macOS vs Linux, as my local permissions of `pcds-logstash/testing/logs` is only user-writeable (`klauer`, `drwxr-xr-x`) and the same docker-compose configuration results in a different outcome ~(either that or the directory wasn't being created to start with? Let me try that once...)~